### PR TITLE
Fix footer social links wrapping on `lg` breakpoint

### DIFF
--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -41,12 +41,12 @@
                         </p>
 
                         <div class="flex flex-wrap lg:flex-col lg:flex-no-wrap">
-                            <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6">
+                            <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
                                 <x-si-x class="text-white w-4 h-4 inline mr-3.5"/>
                                 Twitter
                             </a>
 
-                            <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6">
+                            <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
                                 <x-icon-github class="text-white w-4 h-4 inline mr-3.5"/>
                                 GitHub
                             </a>

--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -42,12 +42,12 @@
 
                         <div class="flex flex-wrap lg:flex-col lg:flex-no-wrap">
                             <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
-                                <x-si-x class="text-white w-4 h-4 inline mr-3.5"/>
+                                <x-si-x class="text-white w-4 h-4 inline mr-2"/>
                                 Twitter
                             </a>
 
                             <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
-                                <x-icon-github class="text-white w-4 h-4 inline mr-3.5"/>
+                                <x-icon-github class="text-white w-4 h-4 inline mr-2"/>
                                 GitHub
                             </a>
                         </div>


### PR DESCRIPTION
This PR adjusts the Social links on the footer so they do not wrap on the `lg` breakpoint, it also adjusts the icon margin to be consistent with the Community links.

Example:
<img width="1512" alt="image" src="https://github.com/tmayrand/laravel.io/assets/61019450/0625bd18-5231-4fbb-a8d4-6df8eacd309a">

